### PR TITLE
add rebar.confg to fix mix source builds

### DIFF
--- a/src/itc.app.src
+++ b/src/itc.app.src
@@ -1,6 +1,6 @@
 {application, itc,
  [{description, "Interval Tree Clocks"},
-  {vsn, "1.0.0"},
+  {vsn, "1.0.1"},
   {modules, [itc]},
   {registered, []},
   {applications, [kernel, stdlib]},


### PR DESCRIPTION
Pushing empty rebar.config to fix source mix builds. Bumped version in app.src as well.